### PR TITLE
feature/50/blacklist-requests-when-the-market-is-not-open

### DIFF
--- a/market_price/validator/forward.py
+++ b/market_price/validator/forward.py
@@ -29,7 +29,7 @@ from market_price.validator.reward import get_rewards
 from market_price.utils.uids import get_random_uids
 
 
-async def forward(self):
+async def execute_forward(self):
     """
     The forward function is called by the validator every time step.
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -180,6 +180,10 @@ class Miner(BaseMinerNeuron):
         """
 
         # input when the ticker does not open market
+        if synapse.movement_prediction is None:
+            bt.logging.warning("No movement prediction (Market is closed or error)")
+            return True, "No movement prediction"
+
         # filter non-miners
 
         if synapse.dendrite is None or synapse.dendrite.hotkey is None:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -25,7 +25,7 @@ import time
 import bittensor as bt
 
 from market_price.base.validator import BaseValidatorNeuron
-from market_price.validator import forward
+from market_price.validator import execute_forward
 
 
 class Validator(BaseValidatorNeuron):
@@ -59,7 +59,7 @@ class Validator(BaseValidatorNeuron):
         - Updating the scores
         """
         # TODO(developer): Rewrite this function based on your protocol definition.
-        return await forward(self)
+        return await execute_forward(self)
 
 
 # The main function parses the configuration and runs the validator.


### PR DESCRIPTION
feature: blacklist request from validator when movement prediction is None